### PR TITLE
Add French-specific PUF Document Status examples and XSD validation script

### DIFF
--- a/examples/country-specific-examples/France/PUF_France_UC10_Affacturee.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC10_Affacturee.xml
@@ -13,11 +13,11 @@
     The seller notifies the buyer that the invoice has been assigned (cédée) to a factor
     and instructs the buyer to direct all payments to the factor's bank account.
 
-    French factoring status codes (outside PUF-016 standard):
-      225 — Affacturée                    : classic (open) factoring, buyer is notified
-      226 — Affacturée Confidentiel       : confidential factoring, seller and factor only
-      227 — Changement de Compte à payer  : update to factoring bank account
-      228 — Non Affacturée                : cancellation / withdrawal of factoring assignment
+    French factoring status codes:
+      FACTORED (225)              — Affacturée: classic (open) factoring, buyer is notified
+      FACTORED_CONFIDENTIAL (226) — Affacturée Confidentiel: confidential factoring, seller and factor only
+      ACCOUNT_CHANGED (227)       — Changement de Compte à payer: update to factoring bank account
+      FACTORING_CANCELLED (228)   — Non Affacturée: cancellation / withdrawal of factoring assignment
 
     The factor bank details (IBAN/BIC) are communicated via the cbc:Note element.
     Buyer must update their accounts payable records to reflect the new payee (factor).
@@ -82,12 +82,10 @@
                 </ext:UBLExtension>
             </ext:UBLExtensions>
             <!--
-                Response Code: 225 = Affacturée (French-specific factoring notification code).
-                This code is outside the standard PUF-016 response code list and is
-                specific to the French e-invoicing lifecycle (CDAR).
-                Code 225 = Classic (open) factoring — buyer is informed and must pay the factor.
+                Response Code: FACTORED = Affacturée (CDAR code 225).
+                Classic (open) factoring — buyer is informed and must pay the factor.
             -->
-            <cbc:ResponseCode>225</cbc:ResponseCode>
+            <cbc:ResponseCode>FACTORED</cbc:ResponseCode>
             <!--
                 Informational status — no reason or action codes required for Affacturée.
                 The factor's identity and bank details are communicated in cbc:Note above.

--- a/examples/country-specific-examples/France/PUF_France_UC13_DirectPaymentRequest.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC13_DirectPaymentRequest.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status — France
+    Use Case: UC13 — Subcontracting (Sous-traitance) — Direct Payment Request
+    Use Case: Subcontractor → Buyer + Main Contractor.
+    Requesting direct payment from the final buyer to the subcontractor (Demande de Paiement Direct).
+    French CDAR status code: 224 (Demande de Paiement Direct)
+
+    Scenario: Private construction market (marché privé de travaux).
+    The SUBCONTRACTOR has invoiced the MAIN CONTRACTOR for earthwork services (F1 invoice,
+    reverse-charged under autoliquidation). The SUBCONTRACTOR now requests direct payment from
+    the final BUYER, bypassing the MAIN CONTRACTOR for this portion.
+
+    Parties:
+      Sender  (Subcontractor): Terrassement Dupont SARL — SIREN 222333444
+      Receiver 1 (Buyer):      Immobilière du Rhône SA — SIREN 555666777
+      Receiver 2 (Main Contractor): BTP Construction Générale SAS — SIREN 888999111
+        (Main Contractor receives the same CDAR message — dual distribution is mandatory)
+
+    Reference invoice (F1): UC13-ST-2026-0100 (Subcontractor → Main Contractor)
+      - 10,000 EUR HT, VAT = 0 (VATEX-FR-AE autoliquidation), TTC = 10,000 EUR
+      - BT-23 = S5 (subcontractor invoice with direct payment)
+
+    The CDAR status 224 is:
+      - Optional in B2B private markets (SUBCONTRACTOR's choice)
+      - Mandatory in B2G public procurement
+    The F1 invoice is attached to this CDAR message (MDT-96).
+
+    PUF Response Code: REQUEST_PAYMENT (maps to French CDAR code 224).
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-FR-UC13-DPR-01</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-04-10</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>10:00:00</cbc:IssueTime>
+    <!--
+        Note communicating the direct payment request details.
+        The BUYER is requested to pay the subcontracted amount directly to the SUBCONTRACTOR.
+    -->
+    <cbc:Note>Demande de paiement direct au titre de l'article 14-1 de la loi n°75-1334 du 31 décembre 1975. Le sous-traitant Terrassement Dupont SARL demande le paiement direct du montant de 10 000,00 EUR par le maître d'ouvrage Immobilière du Rhône SA. IBAN : FR76 1234 5678 9012 3456 7890 123 / BIC : AGRIFRPPXXX.</cbc:Note>
+    <!-- Sender Party (Subcontractor — requests direct payment) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">222333444</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Terrassement Dupont SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!--
+        Receiver Party (Buyer — final buyer who must pay the subcontractor directly).
+        Note: The MAIN CONTRACTOR (BTP Construction Générale SAS, SIREN 888999111) also
+        receives this same CDAR message. Dual distribution to both PA-R (Buyer) and
+        PA-TR (Main Contractor) is mandatory per the specification.
+    -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">555666777</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Immobilière du Rhône SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>13000000001</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!--
+                Response Code: REQUEST_PAYMENT = Demande de Paiement Direct (CDAR code 224).
+                The SUBCONTRACTOR requests the BUYER to pay them directly for the
+                subcontracted portion, instead of paying the MAIN CONTRACTOR.
+            -->
+            <cbc:ResponseCode>REQUEST_PAYMENT</cbc:ResponseCode>
+            <cac:Status>
+                <cbc:StatusReasonCode>NON</cbc:StatusReasonCode>
+                <cbc:StatusReason>Demande de paiement direct du sous-traitant conformément au contrat de sous-traitance accepté par le maître d'ouvrage.</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <!--
+            Reference to the F1 invoice (Subcontractor → Main Contractor).
+            The F1 invoice itself is attached to this CDAR message (MDT-96) per specification.
+        -->
+        <cac:DocumentReference>
+            <!-- F1 invoice number -->
+            <cbc:ID>UC13-ST-2026-0100</cbc:ID>
+            <cbc:IssueDate>2026-04-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_UC14_Visee.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC14_Visee.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status — France
+    Use Case: UC14 — Co-Contracting (Co-traitance) — Lead Contractor Endorsement
+    Use Case: Lead Contractor → Buyer. Endorsing co-contractor invoices (Visée).
+    French CDAR status code: 214 (Visée)
+
+    Scenario: Private construction market (marché privé de travaux) with co-contracting.
+    Multiple CO-CONTRACTORs invoice the BUYER directly. The LEAD CONTRACTOR (chef de file)
+    reviews all F1 invoices (from co-contractors) and F2 (their own), then posts the
+    "Visée" (Endorsed) status to signal to the BUYER that the invoices are validated
+    and ready for grouped processing/payment.
+
+    Parties:
+      Sender  (Lead Contractor): Coordination BTP Marseille SAS — SIREN 444555666
+      Receiver (Buyer):          Promoteur Immobilier Sud SA — SIREN 111222333
+
+    This endorsement applies to co-contractor invoice:
+      Reference invoice (F1): UC14-CC-2026-0050 (Co-contractor → Buyer)
+        - Plumbing works by Plomberie Martin SARL
+        - 15,000 EUR HT + 10% VAT = 16,500 EUR TTC
+        - BT-23 = S6 (co-contractor service invoice)
+
+    Prerequisites:
+      - PA-R (Buyer's platform) must grant the LEAD CONTRACTOR delegated access rights
+      - LEAD CONTRACTOR is identified as AGENT DE VENDEUR (EXT-FR-FE-BG-03) in the
+        co-contractor invoices
+
+    Status 214 (Visée) is conditional:
+      - Only applicable when the BUYER requires the LEAD CONTRACTOR's endorsement
+      - Requires PA-R to support delegated access for the LEAD CONTRACTOR
+
+    PUF Response Code: ENDORSED (maps to French CDAR code 214).
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-FR-UC14-VIS-01</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-05-15</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>11:30:00</cbc:IssueTime>
+    <!--
+        Note from the LEAD CONTRACTOR confirming endorsement of the co-contractor's invoice.
+    -->
+    <cbc:Note>Visa du chef de file : La facture UC14-CC-2026-0050 de Plomberie Martin SARL a été vérifiée et validée par le mandataire Coordination BTP Marseille SAS. Les travaux de plomberie sont conformes au contrat de co-traitance et le montant est approuvé pour paiement groupé.</cbc:Note>
+    <!-- Sender Party (Lead Contractor — endorses co-contractor invoices) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">444555666</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Coordination BTP Marseille SAS</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Buyer — receives endorsement for grouped payment processing) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">111222333</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Promoteur Immobilier Sud SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>14000000001</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!--
+                Response Code: ENDORSED = Visée (CDAR code 214).
+                The LEAD CONTRACTOR validates that the co-contractor's invoice is correct
+                and approved for grouped payment by the BUYER.
+            -->
+            <cbc:ResponseCode>ENDORSED</cbc:ResponseCode>
+            <cac:Status>
+                <cbc:StatusReasonCode>NON</cbc:StatusReasonCode>
+                <cbc:StatusReason>Facture visée par le chef de file conformément au contrat de co-traitance.</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <!--
+            Reference to the F1 invoice (Co-contractor → Buyer).
+            The LEAD CONTRACTOR endorses this invoice after reviewing it on PA-R.
+        -->
+        <cac:DocumentReference>
+            <!-- Co-contractor's F1 invoice number -->
+            <cbc:ID>UC14-CC-2026-0050</cbc:ID>
+            <cbc:IssueDate>2026-05-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_UC22a_PaymentReceived_Discount.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC22a_PaymentReceived_Discount.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status — France
+    Use Case: UC22a — Early Payment Discount (Escompte) — Services, VAT on Cash Basis
+    Use Case: Seller → Buyer. Reporting collection with discount applied (Encaissée).
+    French CDAR status code: 212 (Encaissée)
+    Mandatory reporting to Tax Authority (PPF).
+
+    Scenario: SELLER provides consulting services for 10,000 EUR HT + 20% VAT = 12,000 EUR TTC.
+    Invoice offers "2% discount for payment within 10 days" (BT-21=AAB, BT-22=discount terms).
+    BUYER takes the discount and pays 11,760 EUR (12,000 - 240 discount).
+
+    Parties:
+      Sender  (Seller): Conseil Stratégique Paris SAS — SIREN 333444555
+      Receiver (Buyer): Groupe Industriel Loire SA — SIREN 666777888
+
+    Reference invoice: UC22A-CON-2026-0200
+      - 10,000 EUR HT + 20% VAT = 12,000 EUR TTC
+      - BT-23 = S1 (standard service invoice)
+      - BT-21/BT-22 = AAB / "Escompte de 2% pour paiement sous 10 jours"
+
+    This Encaissée demonstrates the discount pattern:
+      - MEN amount = 11,760 EUR TTC (actual amount received = TTC minus 2% discount)
+      - ESC amount = 240 EUR TTC (discount applied, not collected)
+      - VAT pre-filling at CdD PPF is based on 11,760 EUR (not the original 12,000 EUR)
+
+    The ESC (Escompte appliqué) amount type is defined in the PUF Invoice Response France
+    country specifics (france.adoc) and communicates the discount that was NOT paid.
+    Unlike UC22b (goods/VAT on debits), no credit note is needed — the Encaissée status
+    with the reduced amount automatically adjusts VAT pre-filling.
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-FR-UC22A-001</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-03-20</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>15:00:00</cbc:IssueTime>
+    <!-- Sender Party (Seller — reports collection with discount applied) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">333444555</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Conseil Stratégique Paris SAS</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Buyer — paid with early payment discount) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">666777888</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Groupe Industriel Loire SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>22000000001</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: PAYMENT_RECEIVED = Encaissée (French code 212) -->
+            <cbc:ResponseCode>PAYMENT_RECEIVED</cbc:ResponseCode>
+            <!--
+                Status with two amount types:
+                1. MEN = Amount actually collected (TTC minus discount) — required by Tax Authority
+                2. ESC = Discount applied (amount NOT collected) — informational
+
+                Original invoice: 10,000 HT + 2,000 VAT @ 20% = 12,000 TTC
+                Discount: 2% of 12,000 TTC = 240 EUR
+                Amount received: 12,000 - 240 = 11,760 EUR
+
+                VAT pre-filling at CdD PPF will use 11,760 EUR (MEN), not 12,000 EUR.
+            -->
+            <cac:Status>
+                <ext:UBLExtensions>
+                    <ext:UBLExtension>
+                        <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:StatusExtension</ext:ExtensionURI>
+                        <ext:ExtensionContent>
+                            <puf:PageroExtension>
+                                <puf:StatusExtension>
+                                    <puf:Amounts>
+                                        <!--
+                                            MEN = Amount collected (incl. tax) after discount.
+                                            Required by French Tax Authority.
+                                            11,760 EUR = 12,000 TTC - 240 discount.
+                                        -->
+                                        <puf:Amount>
+                                            <puf:AmountType>MEN</puf:AmountType>
+                                            <cbc:TaxInclusiveAmount currencyID="EUR">11760.00</cbc:TaxInclusiveAmount>
+                                            <puf:ClassifiedTaxCategory>
+                                                <cbc:Percent>20</cbc:Percent>
+                                                <cac:TaxScheme>
+                                                    <cbc:ID>VAT</cbc:ID>
+                                                </cac:TaxScheme>
+                                            </puf:ClassifiedTaxCategory>
+                                            <puf:Date>2026-03-18</puf:Date>
+                                        </puf:Amount>
+                                        <!--
+                                            ESC = Discount applied (escompte).
+                                            Informational — communicates the discount amount NOT collected.
+                                            240 EUR = 2% of 12,000 TTC.
+                                        -->
+                                        <puf:Amount>
+                                            <puf:AmountType>ESC</puf:AmountType>
+                                            <cbc:TaxInclusiveAmount currencyID="EUR">240.00</cbc:TaxInclusiveAmount>
+                                            <puf:ClassifiedTaxCategory>
+                                                <cbc:Percent>20</cbc:Percent>
+                                                <cac:TaxScheme>
+                                                    <cbc:ID>VAT</cbc:ID>
+                                                </cac:TaxScheme>
+                                            </puf:ClassifiedTaxCategory>
+                                        </puf:Amount>
+                                    </puf:Amounts>
+                                </puf:StatusExtension>
+                            </puf:PageroExtension>
+                        </ext:ExtensionContent>
+                    </ext:UBLExtension>
+                </ext:UBLExtensions>
+                <cbc:StatusReasonCode>NON</cbc:StatusReasonCode>
+            </cac:Status>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <cbc:ID>UC22A-CON-2026-0200</cbc:ID>
+            <cbc:IssueDate>2026-03-05</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_UC26_PaymentReceived_Partial.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC26_PaymentReceived_Partial.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status — France
+    Use Case: UC26 — Contractual Reservation Clause (Retenue de Garantie) — Partial Payment
+    Use Case: Seller → Buyer. Reporting partial collection after initial payment (Encaissée).
+    French CDAR status code: 212 (Encaissée)
+    Mandatory reporting to Tax Authority (PPF).
+
+    Scenario: Construction service contract with a 5% retention guarantee (retenue de garantie).
+    SELLER delivers construction services and invoices 20,000 EUR HT + 10% VAT = 22,000 EUR TTC.
+    BUYER pays 95% immediately (20,900 EUR) and withholds 5% (1,100 EUR) pending
+    satisfactory completion (clause de réserve contractuelle).
+
+    The invoice was issued for the FULL amount (BT-112 = 22,000, BT-115 = 22,000).
+    The retention is expressed only as a free-text note (BT-21 = ABU, BT-22 = "clause de réserve").
+    EN 16931 and EXTENDED-CTC-FR do NOT support structured payment schedules with
+    reservation-conditioned amounts.
+
+    Parties:
+      Sender  (Seller): Rénovation Habitat Bordeaux SARL — SIREN 777888999
+      Receiver (Buyer): Groupe Résidentiel Atlantique SA — SIREN 111333555
+
+    Reference invoice: UC26-REN-2026-0075
+      - 20,000 EUR HT + 10% VAT = 22,000 EUR TTC
+      - BT-23 = S1 (standard service invoice)
+      - BT-21/BT-22 = ABU / "Retenue de garantie de 5% conformément au contrat"
+      - VAT on cash basis (services, no debit option)
+
+    This is the FIRST Encaissée for the initial 95% partial payment:
+      - MEN = 20,900 EUR TTC @ 10% (95% of 22,000)
+      - A SECOND Encaissée will follow if and when the reservation clause is lifted
+        and the remaining 5% (1,100 EUR) is paid
+
+    If the reservation is enforced (retention NOT released):
+      - SELLER issues a credit note for 1,100 EUR
+      - No Encaissée is needed for the balance or the credit note
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-FR-UC26-P1-001</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-06-20</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>16:30:00</cbc:IssueTime>
+    <!-- Sender Party (Seller — reports partial collection, 95% of invoice) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">777888999</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Rénovation Habitat Bordeaux SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Buyer — paid 95%, withholding 5% retention guarantee) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">111333555</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Groupe Résidentiel Atlantique SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>26000000001</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: PAYMENT_RECEIVED = Encaissée (French code 212) -->
+            <cbc:ResponseCode>PAYMENT_RECEIVED</cbc:ResponseCode>
+            <!--
+                Status with MEN and RAP amounts for partial payment with retention:
+
+                Invoice total: 20,000 HT + 2,000 VAT @ 10% = 22,000 TTC
+                Initial payment: 95% = 20,900 TTC
+                Retention withheld: 5% = 1,100 TTC (pending reservation clause lift)
+
+                MEN = 20,900 EUR (amount actually collected — 95%)
+                RAP = 1,100 EUR (remaining to pay — 5% retention, conditionally payable)
+
+                VAT pre-filling at CdD PPF is based on 20,900 EUR (amount received so far).
+                A second Encaissée for 1,100 EUR will follow if the clause is lifted.
+            -->
+            <cac:Status>
+                <ext:UBLExtensions>
+                    <ext:UBLExtension>
+                        <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:StatusExtension</ext:ExtensionURI>
+                        <ext:ExtensionContent>
+                            <puf:PageroExtension>
+                                <puf:StatusExtension>
+                                    <puf:Amounts>
+                                        <!--
+                                            MEN = Amount collected (incl. tax) — 95% of invoice.
+                                            Required by French Tax Authority.
+                                            20,900 EUR = 95% of 22,000 TTC.
+                                        -->
+                                        <puf:Amount>
+                                            <puf:AmountType>MEN</puf:AmountType>
+                                            <cbc:TaxInclusiveAmount currencyID="EUR">20900.00</cbc:TaxInclusiveAmount>
+                                            <puf:ClassifiedTaxCategory>
+                                                <cbc:Percent>10</cbc:Percent>
+                                                <cac:TaxScheme>
+                                                    <cbc:ID>VAT</cbc:ID>
+                                                </cac:TaxScheme>
+                                            </puf:ClassifiedTaxCategory>
+                                            <puf:Date>2026-06-15</puf:Date>
+                                        </puf:Amount>
+                                        <!--
+                                            RAP = Remaining to pay (retention withheld).
+                                            Informational — communicates the retention amount still pending.
+                                            1,100 EUR = 5% of 22,000 TTC.
+                                        -->
+                                        <puf:Amount>
+                                            <puf:AmountType>RAP</puf:AmountType>
+                                            <cbc:TaxInclusiveAmount currencyID="EUR">1100.00</cbc:TaxInclusiveAmount>
+                                            <puf:ClassifiedTaxCategory>
+                                                <cbc:Percent>10</cbc:Percent>
+                                                <cac:TaxScheme>
+                                                    <cbc:ID>VAT</cbc:ID>
+                                                </cac:TaxScheme>
+                                            </puf:ClassifiedTaxCategory>
+                                        </puf:Amount>
+                                    </puf:Amounts>
+                                </puf:StatusExtension>
+                            </puf:PageroExtension>
+                        </ext:ExtensionContent>
+                    </ext:UBLExtension>
+                </ext:UBLExtensions>
+                <cbc:StatusReasonCode>NON</cbc:StatusReasonCode>
+            </cac:Status>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <cbc:ID>UC26-REN-2026-0075</cbc:ID>
+            <cbc:IssueDate>2026-05-15</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/README.md
+++ b/examples/country-specific-examples/France/README.md
@@ -31,15 +31,12 @@ Two types of messages are used:
 | `PAYMENT_INITIATED` | 211 | Paiement Transmis | Buyer |
 | `PAYMENT_RECEIVED` | 212 | Encaissée | Seller |
 | `VF` | 213 | Rejetée | Platform |
-| `225` | 225 | Affacturée | Seller |
-| `226` | 226 | Affacturée Confidentiel | Seller/Factor |
-| `227` | 227 | Changement de Compte à payer | Seller/Factor |
-| `228` | 228 | Non Affacturée | Seller |
-
-> **Note on codes 225–228:** These French-specific factoring codes are currently outside the
-> standard PUF-016 code list and are used as raw numeric strings. Dedicated PUF response codes
-> for these statuses are **under consideration/development** and may replace the numeric values
-> in a future release of the PUF Invoice Response specification.
+| `ENDORSED` | 214 | Visée | Lead Contractor |
+| `REQUEST_PAYMENT` | 224 | Demande de Paiement Direct | Subcontractor |
+| `FACTORED` | 225 | Affacturée | Seller |
+| `FACTORED_CONFIDENTIAL` | 226 | Affacturée Confidentiel | Seller/Factor |
+| `ACCOUNT_CHANGED` | 227 | Changement de Compte à payer | Seller/Factor |
+| `FACTORING_CANCELLED` | 228 | Non Affacturée | Seller |
 
 > **Mandatory Tax Authority reporting:** The statuses Déposée (200), Rejetée (213),
 > Refusée (210) and **Encaissée (212)** must be reported to PPF. Encaissée is mandatory
@@ -125,28 +122,63 @@ Second Encaissée for the same invoice:
 
 ---
 
+#### UC13: Subcontracting (Direct Payment Request)
+
+##### 7. `PUF_France_UC13_DirectPaymentRequest.xml`
+
+**Demande de Paiement Direct — Document Status (Subcontractor → Buyer + Main Contractor)**
+Reference: F1 invoice `UC13-ST-2026-0100` (Subcontractor → Main Contractor)
+
+Demonstrates the French-specific CDAR status code `REQUEST_PAYMENT` (224 — Demande de Paiement Direct):
+- Subcontractor requests direct payment from the final BUYER, bypassing the MAIN CONTRACTOR
+- F1 invoice: 10,000 EUR (reverse-charged, VATEX-FR-AE autoliquidation)
+- BT-23 = S5 (subcontractor invoice with direct payment)
+- Subcontractor's bank details communicated via `cbc:Note`
+
+> **Dual distribution**: This CDAR message must be sent simultaneously to **both** the BUYER
+> (PA-R) and the MAIN CONTRACTOR (PA-TR). The `cac:ReceiverParty` shows the BUYER; the
+> MAIN CONTRACTOR also receives the same message.
+
+> Optional in B2B private markets, mandatory in B2G public procurement.
+
+---
+
+#### UC14: Co-Contracting (Lead Contractor Endorsement)
+
+##### 8. `PUF_France_UC14_Visee.xml`
+
+**Visée — Document Status (Lead Contractor → Buyer)**
+Reference: F1 invoice `UC14-CC-2026-0050` (Co-contractor → Buyer)
+
+Demonstrates the French-specific CDAR status code `ENDORSED` (214 — Visée):
+- Lead contractor (chef de file) endorses a co-contractor's invoice
+- Signals to the BUYER that the invoice is validated and approved for grouped payment
+- BT-23 = S6 (co-contractor service invoice)
+- Requires PA-R to grant the LEAD CONTRACTOR delegated access rights
+
+> Conditional on BUYER requiring endorsement and PA-R supporting delegated access.
+
+---
+
 #### UC10: Post-Factoring
 
-##### 7. `PUF_France_UC10_Affacturee.xml`
+##### 9. `PUF_France_UC10_Affacturee.xml`
 
 **Affacturée — Document Status (Seller → Buyer)**
 Reference: `PUF_France_UC10_PostFactoring_Invoice.xml` — invoice `UC10-IND-2026-0345`
 
-Demonstrates the French-specific factoring notification code `225` (Affacturée):
+Demonstrates the French-specific factoring notification code `FACTORED` (225 — Affacturée):
 - Seller notifies buyer that the invoice has been assigned (cédée) to a factor
 - Factor's bank details communicated via `cbc:Note`
 - Buyer must redirect payment to the factor
 
-> Response code `225` is outside the standard PUF-016 code list and is specific to French CDAR.
-> Related codes: 226 (Affacturée Confidentiel), 227 (Changement de Compte), 228 (Non Affacturée).
-> Dedicated PUF response codes for these statuses are **under consideration/development** and may
-> replace the numeric values in a future release of the PUF Invoice Response specification.
+> Related codes: `FACTORED_CONFIDENTIAL` (226), `ACCOUNT_CHANGED` (227), `FACTORING_CANCELLED` (228).
 
 ---
 
 #### UC19b: Self-Billing
 
-##### 8. `PUF_France_UC19b_PaymentReceived.xml`
+##### 10. `PUF_France_UC19b_PaymentReceived.xml`
 
 **Encaissée — Document Status (Seller → Buyer)**
 Reference: `PUF_France_UC19b_SelfBilling_Invoice.xml` — invoice `SMBF-AF-2026-01234`
@@ -159,9 +191,48 @@ Demonstrates Encaissée for a self-billing scenario:
 
 ---
 
+#### UC22a: Early Payment Discount (Escompte)
+
+##### 11. `PUF_France_UC22a_PaymentReceived_Discount.xml`
+
+**Encaissée with Discount — Document Status (Seller → Buyer)**
+Reference: invoice `UC22A-CON-2026-0200` (consulting services, 12,000 EUR TTC @ 20%)
+
+Demonstrates Encaissée when a 2% early payment discount (escompte) has been applied:
+- MEN = **11,760.00 EUR TTC @ 20%** — actual amount received (12,000 − 240 discount)
+- ESC = **240.00 EUR TTC @ 20%** — discount applied (amount NOT collected)
+- VAT pre-filling at CdD PPF uses the MEN amount (11,760), not the invoice total (12,000)
+
+> For services with VAT on cash basis (UC22a), the discount is automatically accounted
+> for in the Encaissée amount — **no credit note is needed**. The `ESC` amount type is
+> informational and communicates the discount to the receiving party.
+
+---
+
+#### UC26: Contractual Reservation Clause (Retenue de Garantie)
+
+##### 12. `PUF_France_UC26_PaymentReceived_Partial.xml`
+
+**Encaissée (partial, 95%) — Document Status (Seller → Buyer)**
+Reference: invoice `UC26-REN-2026-0075` (construction services, 22,000 EUR TTC @ 10%)
+
+Demonstrates the first Encaissée for a partial payment with retention guarantee:
+- MEN = **20,900.00 EUR TTC @ 10%** — 95% initial payment received
+- RAP = **1,100.00 EUR TTC @ 10%** — 5% retention withheld (remaining to pay)
+- Invoice note BT-21 = ABU / BT-22 = "clause de réserve" on the referenced invoice
+
+> A second Encaissée for 1,100 EUR will follow if/when the reservation clause is lifted.
+> If retention is enforced (not released), the SELLER issues a credit note instead —
+> no Encaissée is needed for the balance or the credit note.
+>
+> This differs from UC4 (split payer): here the **same** BUYER pays in phases,
+> rather than multiple payers splitting the amount.
+
+---
+
 #### UC40: Netting / Compensation
 
-##### 9. `PUF_France_UC40_PaymentReceived.xml`
+##### 13. `PUF_France_UC40_PaymentReceived.xml`
 
 **Encaissée — Document Status (Seller → Buyer)**
 Reference: `PUF_France_UC40_Netting_Invoice2_FarmerToCoop.xml` — invoice `EARL-2026-0089`

--- a/validation-artefacts/validate_xsd.py
+++ b/validation-artefacts/validate_xsd.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+XSD Validation Script for PUF Examples
+Validates XML files against PageroUniversalFormat XSD schema
+"""
+
+import sys
+import os
+from pathlib import Path
+from lxml import etree
+
+# Configuration
+REPO_ROOT = Path(__file__).parent.parent  # puf-billing root
+XSD_DIR = REPO_ROOT / "xml-schemas" / "maindoc"
+XSD = XSD_DIR / "PUF-ApplicationResponse-2.3.xsd"  # Default schema (will auto-detect)
+EXAMPLES_DIR = REPO_ROOT / "examples"
+XML_PATTERN = "**/*.xml"  # Recursive pattern
+
+
+def get_root_element(xml_path: Path) -> str:
+    """
+    Get the root element name from an XML file.
+    
+    Returns:
+        str: Root element local name (without namespace)
+    """
+    try:
+        tree = etree.parse(str(xml_path))
+        root = tree.getroot()
+        # Get local name without namespace
+        return etree.QName(root).localname
+    except Exception as e:
+        return None
+
+
+def validate_xml_file(xml_path: Path, schema: etree.XMLSchema) -> tuple[bool, list[str], str]:
+    """
+    Validate a single XML file against the appropriate schema.
+    
+    Returns:
+        tuple: (is_valid, error_messages, schema_used)
+    """
+    try:
+        # Detect root element
+        root_element = get_root_element(xml_path)
+        
+        if root_element is None:
+            return False, ["Could not determine root element"], "Unknown"
+        
+        # Select appropriate schema
+        if root_element == "ApplicationResponse":
+            schema = schema
+            schema_name = "ApplicationResponse"
+        else:
+            return False, [f"Unknown root element: {root_element}"], "Unknown"
+        
+        # Parse XML
+        xml_doc = etree.parse(str(xml_path))
+        
+        # Validate
+        is_valid = schema.validate(xml_doc)
+        
+        if is_valid:
+            return True, [], schema_name
+        else:
+            # Collect error messages
+            errors = []
+            for error in schema.error_log:
+                errors.append(
+                    f"Line {error.line}: {error.message}"
+                )
+            return False, errors, schema_name
+            
+    except etree.XMLSyntaxError as e:
+        return False, [f"XML Syntax Error: {str(e)}"], "Unknown"
+    except Exception as e:
+        return False, [f"Exception: {str(e)}"], "Unknown"
+
+
+def main():
+    """Main validation routine."""
+    
+    print("\n=== XSD Validation Report (Python/lxml) ===\n")
+    print(f"XSD Schema: {XSD.name}")
+    print(f"Examples directory: {EXAMPLES_DIR}")
+    print()
+    
+    # Check if XSD files exist
+    if not XSD.exists():
+        print(f"[ERROR] ApplicationResponse XSD schema not found at: {XSD}")
+        sys.exit(1)
+    
+    # Check if examples directory exists
+    if not EXAMPLES_DIR.exists():
+        print(f"[ERROR] Examples directory not found at: {EXAMPLES_DIR}")
+        sys.exit(1)
+    
+    # Load both XSD schemas
+    try:
+        print("Loading XSD schemas...")
+        application_response_schema_doc = etree.parse(str(XSD))
+        application_response_schema = etree.XMLSchema(application_response_schema_doc)
+        print(f"[OK] ApplicationResponse schema loaded successfully")
+    except Exception as e:
+        print(f"[ERROR] Failed to load XSD schemas: {e}")
+        sys.exit(1)
+    
+    # Find XML files
+    xml_files = sorted(EXAMPLES_DIR.glob(XML_PATTERN))
+    
+    if not xml_files:
+        print(f"[ERROR] No XML files found in: {EXAMPLES_DIR}")
+        sys.exit(1)
+    
+    print(f"Found {len(xml_files)} XML files to validate\n")
+    print("-" * 80)
+    
+    # Validate each file
+    valid_count = 0
+    invalid_count = 0
+    error_details = []
+    schema_stats = {"ApplicationResponse": 0, "Unknown": 0}
+    
+    for xml_file in xml_files:
+        # Get relative path for display
+        try:
+            rel_path = xml_file.relative_to(EXAMPLES_DIR)
+        except ValueError:
+            rel_path = xml_file.name
+            
+        is_valid, errors, schema_used = validate_xml_file(xml_file, application_response_schema)
+        
+        schema_stats[schema_used] = schema_stats.get(schema_used, 0) + 1
+        
+        if is_valid:
+            print(f"[PASS] {rel_path} ({schema_used})")
+            valid_count += 1
+        else:
+            print(f"[FAIL] {rel_path} ({schema_used})")
+            invalid_count += 1
+            error_details.append({
+                'file': str(rel_path),
+                'schema': schema_used,
+                'errors': errors
+            })
+    
+    # Summary
+    print("\n" + "=" * 80)
+    print(f"\n=== Summary ===")
+    print(f"Total files:     {len(xml_files)}")
+    print(f"[PASS] Valid:    {valid_count}")
+    print(f"[FAIL] Invalid:  {invalid_count}")
+    print(f"\nBy Schema:")
+    print(f"  ApplicationResponse:       {schema_stats.get('ApplicationResponse', 0)}")
+    if schema_stats.get('Unknown', 0) > 0:
+        print(f"  Unknown:       {schema_stats.get('Unknown', 0)}")
+    
+    # Detailed errors
+    if error_details:
+        print(f"\n=== Detailed Validation Errors ===\n")
+        for item in error_details:
+            print(f"\n{item['file']} ({item['schema']}) - {len(item['errors'])} errors:")
+            print("-" * 80)
+            for i, error in enumerate(item['errors'], 1):
+                print(f"{i}. {error}")
+            print()
+    
+    print()
+    return 0 if invalid_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Introduced new XML files for use cases UC13 (Direct Payment Request), UC14 (Lead Contractor Endorsement), UC22a (Early Payment Discount), and UC26 (Contractual Reservation Clause) demonstrating specific French CDAR status codes.
- Updated README.md to include new use cases and their descriptions.
- Added a Python script for validating XML files against the PUF XSD schema, ensuring compliance with the Pagero Universal Format standards.