### PR TITLE
Add France CDAR lifecycle and factoring invoice-response examples

### DIFF
--- a/examples/country-specific-examples/France/PUF_France_201_Issued.xml
+++ b/examples/country-specific-examples/France/PUF_France_201_Issued.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Invoice Response - France
+    Use Case: Platform -> Seller. The platform (PA-E) has issued and sent the invoice from the sender's service provider to the recipient's service provider.
+    French CDAR status code: 201 (Émise par la plateforme) - PUF ResponseCode "ISSUED_BY_PLATFORM".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL -> Entreprise Client France SA)
+    Sender   (Platform): Thomson Reuters
+    Receiver (Seller): TechDistrib France SARL + SIREN 987654321
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:invoice_response:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:invoice_response:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-201-ISSUED</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-10</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>09:35:00</cbc:IssueTime>
+    <!-- Sender Party (Platform - sends ISSUED_BY_PLATFORM/Émise par la plateforme status) -->
+    <cac:SenderParty>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Thomson Reuters</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Seller - receives ISSUED_BY_PLATFORM/Émise par la plateforme status) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code and optional extensions -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- The interchange id of the referenced document. If sent by the issuer -->
+                                <puf:ReferencedDocumentInterchangeID>
+                                    <cbc:ID>111222301</cbc:ID>
+                                </puf:ReferencedDocumentInterchangeID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: ISSUED_BY_PLATFORM = Émise par la plateforme (French code 201) -->
+            <cbc:ResponseCode>ISSUED_BY_PLATFORM</cbc:ResponseCode>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_202_Received.xml
+++ b/examples/country-specific-examples/France/PUF_France_202_Received.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Invoice Response - France
+    Use Case: Platform → Seller. The recipient's service provider (PA-R) has acknowledged and received the invoice, not yet delivered to the end recipient.
+    French CDAR status code: 202 (Reçue par la plateforme) - PUF ResponseCode "RECEIVED_BY_PLATFORM".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL → Entreprise Client France SA)
+    Sender   (Platform): Thomson Reuters
+    Receiver (Seller): TechDistrib France SARL + SIREN 987654321
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:invoice_response:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:invoice_response:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-202-RECEIVED</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-10</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>09:40:00</cbc:IssueTime>
+    <!-- Sender Party (Platform - sends RECEIVED_BY_PLATFORM/REÇUE PAR LA PLATEFORME status) -->
+    <cac:SenderParty>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Thomson Reuters</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Seller - receives RECEIVED_BY_PLATFORM/REÇUE PAR LA PLATEFORME status) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- The interchange id of the referenced document. If sent by the issuer -->
+                                <puf:ReferencedDocumentInterchangeID>
+                                    <cbc:ID>111222302</cbc:ID>
+                                </puf:ReferencedDocumentInterchangeID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: RECEIVED_BY_PLATFORM = Reçue par la plateforme (French code 202) -->
+            <cbc:ResponseCode>RECEIVED_BY_PLATFORM</cbc:ResponseCode>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_203_MadeAvailable.xml
+++ b/examples/country-specific-examples/France/PUF_France_203_MadeAvailable.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Invoice Response - France
+    Use Case: Platform → Seller. The invoice has been delivered to the end recipient (buyer) by their service provider.
+    French CDAR status code: 203 (Mise à disposition) - PUF ResponseCode "MADE_AVAILABLE".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL → Entreprise Client France SA)
+    Sender   (Platform): Thomson Reuters
+    Receiver (Seller):   TechDistrib France SARL + SIREN 987654321
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:invoice_response:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:invoice_response:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-203-AVAIL</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-10</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>10:00:00</cbc:IssueTime>
+    <!-- Sender Party (Platform - sends MADE_AVAILABLE/Mise à disposition status) -->
+    <cac:SenderParty>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Thomson Reuters</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Seller - receives MADE_AVAILABLE/Mise à disposition status) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- The interchange id of the referenced document. If sent by the issuer -->
+                                <puf:ReferencedDocumentInterchangeID>
+                                    <cbc:ID>111222303</cbc:ID>
+                                </puf:ReferencedDocumentInterchangeID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: MADE_AVAILABLE = Mise à disposition (French code 203) -->
+            <cbc:ResponseCode>MADE_AVAILABLE</cbc:ResponseCode>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_204_Acknowledged.xml
+++ b/examples/country-specific-examples/France/PUF_France_204_Acknowledged.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Invoice Response - France
+    Use Case: Buyer -> Seller. The buyer has started processing the invoice in its system (prise en charge).
+    French CDAR status code: 204 (Prise en charge) - PUF ResponseCode "IP".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL -> Entreprise Client France SA)
+    Sender   (Buyer):  Entreprise Client France SA + SIREN 123456789
+    Receiver (Seller): TechDistrib France SARL + SIREN 987654321
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:invoice_response:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:invoice_response:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-204-IP</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-11</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>08:00:00</cbc:IssueTime>
+    <!-- Sender Party (Buyer - sends Invoice Response) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">123456789</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Entreprise Client France SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Seller - receives Invoice Response) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- DocumentMatchingID links this response to the original transaction -->
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10000000204</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: IP = Prise en charge (French code 204) -->
+            <cbc:ResponseCode>IP</cbc:ResponseCode>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_205_Approved.xml
+++ b/examples/country-specific-examples/France/PUF_France_205_Approved.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Invoice Response - France
+    Use Case: Buyer -> Seller. The buyer has given final approval of the invoice; the next step is payment.
+    French CDAR status code: 205 (Approuvee) - PUF ResponseCode "AP".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL -> Entreprise Client France SA)
+    Sender   (Buyer): Entreprise Client France SA + SIREN 123456789
+    Receiver (Seller): TechDistrib France SARL + SIREN 987654321
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:invoice_response:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:invoice_response:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-205-AP</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-12</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>14:00:00</cbc:IssueTime>
+    <!-- Sender Party (Buyer - sends Invoice Response) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">123456789</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Entreprise Client France SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Seller - receives Invoice Response) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- DocumentMatchingID links this response to the original transaction -->
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10000000205</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: AP = Approuvee (French code 205) -->
+            <cbc:ResponseCode>AP</cbc:ResponseCode>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_206_PartiallyApproved.xml
+++ b/examples/country-specific-examples/France/PUF_France_206_PartiallyApproved.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Invoice Response — France
+    Use Case: Buyer → Seller. Buyer accepts part of the invoice and declines another part (a reason code is mandatory for 206).
+    French CDAR status code: 206 (Approuvée partiellement) - PUF ResponseCode "PARTIALLY_ACCEPTED".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL → Entreprise Client France SA)
+    Sender   (Buyer):  Entreprise Client France SA — SIREN 123456789
+    Receiver (Seller): TechDistrib France SARL — SIREN 987654321
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:invoice_response:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:invoice_response:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-206-PARTIAL</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-12</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>14:30:00</cbc:IssueTime>
+    <!-- Sender Party (Buyer — sends Invoice Response) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">123456789</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Entreprise Client France SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Seller — receives Invoice Response) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code and reason/action -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- DocumentMatchingID links this response to the original transaction -->
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10000000206</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: PARTIALLY_ACCEPTED = Approuvée partiellement (French code 206) -->
+            <cbc:ResponseCode>PARTIALLY_ACCEPTED</cbc:ResponseCode>
+            <!-- Status with approved/not-approved amount breakdown and mandatory reason code (206) -->
+            <cac:Status>
+                <ext:UBLExtensions>
+                    <ext:UBLExtension>
+                        <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:StatusExtension</ext:ExtensionURI>
+                        <ext:ExtensionContent>
+                            <puf:PageroExtension>
+                                <puf:StatusExtension>
+                                    <puf:Clarifications>
+                                        <!--
+                                            MAPTTC = Gross Amount Approved (incl. tax).
+                                            The portion of the invoice the buyer accepts.
+                                        -->
+                                        <puf:Clarification>
+                                            <puf:TypeCode>MAPTTC</puf:TypeCode>
+                                            <puf:ValuePercent>20</puf:ValuePercent>
+                                            <puf:ValueAmount>960.00</puf:ValueAmount>
+                                            <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>
+                                        </puf:Clarification>
+                                        <!--
+                                            MNATTC = Gross Amount NOT Approved (incl. tax).
+                                            The portion of the invoice the buyer declines.
+                                        -->
+                                        <puf:Clarification>
+                                            <puf:TypeCode>MNATTC</puf:TypeCode>
+                                            <puf:ValuePercent>20</puf:ValuePercent>
+                                            <puf:ValueAmount>240.00</puf:ValueAmount>
+                                            <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>
+                                        </puf:Clarification>
+                                    </puf:Clarifications>
+                                </puf:StatusExtension>
+                            </puf:PageroExtension>
+                        </ext:ExtensionContent>
+                    </ext:UBLExtension>
+                </ext:UBLExtensions>
+                <!--
+                    Reason code (why the invoice is only partially approved).
+                    listID="OPStatusReason" identifies this as a reason code status.
+                    QTE_ERR = quantity error. Mandatory reason code for code 206.
+                -->
+                <cbc:StatusReasonCode listID="OPStatusReason">QTE_ERR</cbc:StatusReasonCode>
+                <cbc:StatusReason>Quantité facturée supérieure à la quantité livrée sur la ligne 1 : 8 unités acceptées sur 10 facturées. Montant approuvé 960,00 EUR TTC, montant non approuvé 240,00 EUR TTC.</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_208_Suspended.xml
+++ b/examples/country-specific-examples/France/PUF_France_208_Suspended.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Invoice Response — France
+    Use Case: Buyer → Seller. The buyer suspends processing (Suspendue) pending a mandatory contractual reference that is missing.
+    French CDAR status code: 208 (Suspendue) - PUF ResponseCode "ON_HOLD".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL → Entreprise Client France SA)
+    Sender   (Buyer):  Entreprise Client France SA — SIREN 123456789
+    Receiver (Seller): TechDistrib France SARL — SIREN 987654321
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:invoice_response:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:invoice_response:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-208-SUSPEND</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-11</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>16:30:00</cbc:IssueTime>
+    <!-- Sender Party (Buyer — sends Invoice Response) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">123456789</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Entreprise Client France SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Seller — receives Invoice Response) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code and reason -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- DocumentMatchingID links this response to the original transaction -->
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10000000208</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: ON_HOLD = Suspendue (French code 208) -->
+            <cbc:ResponseCode>ON_HOLD</cbc:ResponseCode>
+            <!--
+                Status — Reason code (why processing is suspended).
+                listID="OPStatusReason" identifies this as a reason code status.
+                REF_CT_ABSENT = mandatory contractual reference is missing.
+                Reason code is mandatory for response code ON_HOLD (208) per French spec.
+            -->
+            <cac:Status>
+                <cbc:StatusReasonCode listID="OPStatusReason">REF_CT_ABSENT</cbc:StatusReasonCode>
+                <cbc:StatusReason>Référence contractuelle obligatoire absente : le numéro de contrat (BT-12) est requis pour le traitement. Traitement suspendu dans l'attente de cette référence.</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_209_InformationProvided.xml
+++ b/examples/country-specific-examples/France/PUF_France_209_InformationProvided.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status - France
+    Use Case: Seller -> Buyer. The seller provides the information previously requested by the buyer's query (UQ/207), fulfilling the request.
+    French CDAR status code: 209 (Complétée (Complément d'informations)) - PUF ResponseCode "INFORMATION_PROVIDED".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL -> Entreprise Client France SA)
+    Sender   (Seller): TechDistrib France SARL + SIREN 987654321
+    Receiver (Buyer): Entreprise Client France SA + SIREN 123456789
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-209-INFO</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-13</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>09:00:00</cbc:IssueTime>
+    <!--
+        Note carrying the information provided in response to the buyer's query (status 207).
+    -->
+    <cbc:Note>Complément d'informations fourni en réponse à la mise en litige (statut 207) : le taux de TVA correct est de 20%. Une facture rectificative sera émise.</cbc:Note>
+    <!-- Sender Party (Seller - provides the requested information) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Buyer - had requested the information) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">123456789</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Entreprise Client France SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code and reason -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- DocumentMatchingID links this response to the original transaction -->
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10000000209</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: INFORMATION_PROVIDED = Complétée (Complément d'informations) (French code 209) -->
+            <cbc:ResponseCode>INFORMATION_PROVIDED</cbc:ResponseCode>
+            <!-- Informational status: no reason code applies; the information is conveyed in cbc:StatusReason and cbc:Note above. -->
+            <cac:Status>
+                <cbc:StatusReason>Complément d'informations fourni en réponse à la demande de l'acheteur.</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_220_Cancelled.xml
+++ b/examples/country-specific-examples/France/PUF_France_220_Cancelled.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status - France
+    Use Case: Seller -> Buyer. The seller (issuer) cancels the invoice following the creation of a corrective credit note (avoir).
+    French CDAR status code: 220 (Annulée) - PUF ResponseCode "SUPERSEDED".
+    Reference invoice: FR-INV-2026-001 (TechDistrib France SARL -> Entreprise Client France SA)
+    Sender   (Seller): TechDistrib France SARL + SIREN 987654321
+    Receiver (Buyer): Entreprise Client France SA + SIREN 123456789
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-220-CANCEL</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-20</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>10:00:00</cbc:IssueTime>
+    <!--
+        Note explaining the cancellation.
+        The invoice is cancelled following the issuance of a corrective credit note (avoir).
+    -->
+    <cbc:Note>Facture FR-INV-2026-001 annulée suite à l'émission de l'avoir FR-CN-2026-001. Une facture rectificative la remplacera.</cbc:Note>
+    <!-- Sender Party (Seller - issuer cancels the invoice) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">987654321</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Buyer - receives the cancellation status) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">123456789</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Entreprise Client France SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <!-- Response element containing the status code and reason -->
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <!-- DocumentMatchingID links this response to the original transaction -->
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10000000220</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- Response Code: SUPERSEDED = Annulée (French code 220) -->
+            <cbc:ResponseCode>SUPERSEDED</cbc:ResponseCode>
+            <!-- Informational status: no reason code applies; the cancellation context is given in cbc:StatusReason. -->
+            <cac:Status>
+                <cbc:StatusReason>Facture annulée par l'émetteur suite à l'émission d'une facture corrective (avoir).</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <!-- Reference to the original invoice -->
+        <cac:DocumentReference>
+            <!-- Invoice number of the referenced document -->
+            <cbc:ID>FR-INV-2026-001</cbc:ID>
+            <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_UC10_AffactureeConfidentiel.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC10_AffactureeConfidentiel.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status - France
+    Use Case: Seller -> Factor. Confidential factoring assignment shared between the seller and the factor ONLY (the buyer is NOT informed). Receiver is the FACTOR, not the buyer.
+    French CDAR status code: 226 (Affacturee Confidentiel) - PUF ResponseCode "FACTORED_CONFIDENTIAL".
+    Reference invoice: UC10-IND-2026-0345 (IndustrialTech Lyon SA -> Automotive Suppliers Network SAS)
+    Sender   (Seller): IndustrialTech Lyon SA + SIREN 111222333
+    Receiver (Factor): France Capital Factoring SA + SIREN 444555666
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-226-FACCONF</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-01</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>08:00:00</cbc:IssueTime>
+    <!--
+        Confidential factoring note. This status is exchanged between the seller and the factor only.
+        The buyer is not informed of the assignment.
+    -->
+    <cbc:Note>Affacturage confidentiel : facture cedee a France Capital Factoring SA. Statut partage entre le vendeur et l'affactureur uniquement. NE PAS transmettre a l'acheteur (ni a sa PA-R).</cbc:Note>
+    <!-- Sender Party (Seller - assigns the receivable to the factor) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">111222333</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>IndustrialTech Lyon SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Factor - receives the confidential factoring status) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">444555666</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>France Capital Factoring SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10100000002</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!--
+                Response Code: FACTORED_CONFIDENTIAL = Affacturee Confidentiel (CDAR code 226).
+                Confidential factoring - the status is shared between the seller and the factor only.
+            -->
+            <cbc:ResponseCode>FACTORED_CONFIDENTIAL</cbc:ResponseCode>
+            <!--
+                Informational status - no reason or action codes required for Affacturee Confidentiel.
+            -->
+            <cac:Status>
+                <cbc:StatusReason>Cession de creance en affacturage confidentiel (loi Dailly).</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <cac:DocumentReference>
+            <cbc:ID>UC10-IND-2026-0345</cbc:ID>
+            <cbc:IssueDate>2026-01-30</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_UC10_ChangementDeCompte.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC10_ChangementDeCompte.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status - France
+    Use Case: Seller -> Buyer. The seller notifies the buyer of a change of payment account (new IBAN/BIC), e.g. following a confidential factoring arrangement; the beneficiary stays the seller.
+    French CDAR status code: 227 (Changement de Compte a payer) - PUF ResponseCode "ACCOUNT_CHANGED".
+    Reference invoice: UC10-IND-2026-0345 (IndustrialTech Lyon SA -> Automotive Suppliers Network SAS)
+    Sender   (Seller): IndustrialTech Lyon SA + SIREN 111222333
+    Receiver (Buyer): Automotive Suppliers Network SAS + SIREN 777888999
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-227-ACCCHG</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-02</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>08:00:00</cbc:IssueTime>
+    <!--
+        Note communicating the new payment account details.
+        The beneficiary remains the seller; only the bank account changes.
+    -->
+    <cbc:Note>Changement de compte a payer : veuillez regler cette facture sur le nouveau compte IBAN FR76 3000 4000 5000 6000 7000 123 / BIC BNPAFRPPXXX. Le beneficiaire reste IndustrialTech Lyon SA.</cbc:Note>
+    <!-- Sender Party (Seller - notifies buyer of the change of payment account) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">111222333</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>IndustrialTech Lyon SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Buyer - must pay to the new bank account) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">777888999</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Automotive Suppliers Network SAS</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10100000003</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!--
+                Response Code: ACCOUNT_CHANGED = Changement de Compte a payer (CDAR code 227).
+                Update to the payment bank account; the beneficiary remains the seller.
+            -->
+            <cbc:ResponseCode>ACCOUNT_CHANGED</cbc:ResponseCode>
+            <!--
+                Informational status - no reason or action codes required.
+                The new bank account details are communicated in cbc:Note above.
+            -->
+            <cac:Status>
+                <cbc:StatusReason>Modification des coordonnees bancaires de reglement (BT-84 IBAN, BT-85 nom du compte, BT-86 BIC).</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <cac:DocumentReference>
+            <cbc:ID>UC10-IND-2026-0345</cbc:ID>
+            <cbc:IssueDate>2026-01-30</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/PUF_France_UC10_NonAffacturee.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC10_NonAffacturee.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF Document Status - France
+    Use Case: Seller -> Buyer. The seller cancels the factoring assignment; payment reverts to the seller's own account.
+    French CDAR status code: 228 (Non Affacturée) - PUF ResponseCode "FACTORING_CANCELLED".
+    Reference invoice: UC10-IND-2026-0345 (IndustrialTech Lyon SA -> Automotive Suppliers Network SAS)
+    Sender   (Seller): IndustrialTech Lyon SA + SIREN 111222333
+    Receiver (Buyer): Automotive Suppliers Network SAS + SIREN 777888999
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+                     xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Specification Identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:document_status:1.0</cbc:CustomizationID>
+    <!-- Business process type identifier -->
+    <cbc:ProfileID>urn:pagero.com:puf:document_status:1.0</cbc:ProfileID>
+    <!-- Response identifier (max 20 characters) -->
+    <cbc:ID>RESP-228-NONFAC</cbc:ID>
+    <!-- Response issue date -->
+    <cbc:IssueDate>2026-02-03</cbc:IssueDate>
+    <!-- Response issue time (mandatory in France) -->
+    <cbc:IssueTime>08:00:00</cbc:IssueTime>
+    <!--
+        Note communicating the end of factoring.
+        Payment reverts to the seller's own bank account.
+    -->
+    <cbc:Note>Fin d'affacturage : la facture n'est plus cédée à un affactureur. Veuillez régler IndustrialTech Lyon SA sur son compte habituel IBAN FR76 1234 5678 9012 3456 7890 123 / BIC BNPAFRPPXXX.</cbc:Note>
+    <!-- Sender Party (Seller - cancels the factoring assignment) -->
+    <cac:SenderParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">111222333</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>IndustrialTech Lyon SA</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <!-- Receiver Party (Buyer - must pay the seller again instead of the factor) -->
+    <cac:ReceiverParty>
+        <cac:PartyIdentification>
+            <!-- SIREN identifier (scheme 0002) -->
+            <cbc:ID schemeID="0002">777888999</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Automotive Suppliers Network SAS</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <!-- Document Response -->
+    <cac:DocumentResponse>
+        <cac:Response>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ResponseExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:ResponseExtension>
+                                <puf:DocumentMatchingID>
+                                    <cbc:ID>10100000004</cbc:ID>
+                                </puf:DocumentMatchingID>
+                            </puf:ResponseExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!--
+                Response Code: FACTORING_CANCELLED = Non Affacturée (CDAR code 228).
+                Cancellation of the factoring assignment - buyer pays the seller again.
+            -->
+            <cbc:ResponseCode>FACTORING_CANCELLED</cbc:ResponseCode>
+            <!--
+                Informational status - no reason or action codes required for Non Affacturée.
+                The seller's bank details are communicated in cbc:Note above.
+            -->
+            <cac:Status>
+                <cbc:StatusReason>Annulation de l'affacturage : le règlement est de nouveau dû au vendeur sur son compte habituel.</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <cac:DocumentReference>
+            <cbc:ID>UC10-IND-2026-0345</cbc:ID>
+            <cbc:IssueDate>2026-01-30</cbc:IssueDate>
+            <!-- Document type code: 380 = Invoice -->
+            <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>

--- a/examples/country-specific-examples/France/README.md
+++ b/examples/country-specific-examples/France/README.md
@@ -191,7 +191,7 @@ Demonstrates the French-specific CDAR status code `REQUEST_PAYMENT` (224 — Dem
 > **Dual distribution**: This CDAR message must be sent simultaneously to **both** the BUYER
 > (PA-R) and the MAIN CONTRACTOR (PA-TR). The `cac:ReceiverParty` shows the BUYER; the
 > MAIN CONTRACTOR also receives the same message.
-
+>
 > Optional in B2B private markets, mandatory in B2G public procurement.
 
 ---
@@ -358,7 +358,7 @@ Net declared amount for VAT pre-filling: +12,000 − 10,000 = **+2,000 EUR** (VA
 
 #### 207: Under Query / Dispute (En litige) with Clarifications
 
-##### 19. `PUF_France_207_UnderQuery.xml`
+##### 19. `PUF_France_Generic_UnderQuery.xml`
 
 **En litige — Invoice Response (Buyer → Seller)**
 Reference invoice: `FR-INV-2026-001` (TechDistrib France SARL → Entreprise Client France SA)
@@ -379,6 +379,58 @@ alongside a reason and a requested action:
 > codes (`DIV` current value, `DVA` expected value, `MAJ` replacement, `CBB`) describe
 > *non-monetary* field-level discrepancies. To report both the current and expected value of a
 > field, send two clarifications (DIV + DVA) sharing the same `puf:Code`/`puf:Location`.
+
+---
+
+## Complete CDAR Lifecycle Coverage
+
+The examples below complete coverage of all 21 French CDAR status codes. The generic lifecycle statuses
+reference invoice `FR-INV-2026-001` (TechDistrib France SARL → Entreprise Client France SA); the factoring
+statuses reference invoice `UC10-IND-2026-0345` (IndustrialTech Lyon SA → Automotive Suppliers Network SAS).
+
+### Platform Routing Statuses (Platform → Seller, Invoice Response)
+
+| File | Code | Status | ResponseCode |
+|------|------|--------|--------------|
+| `PUF_France_201_Issued.xml` | 201 | Émise par la plateforme | `ISSUED_BY_PLATFORM` |
+| `PUF_France_202_Received.xml` | 202 | Reçue par la plateforme | `RECEIVED_BY_PLATFORM` |
+| `PUF_France_203_MadeAvailable.xml` | 203 | Mise à disposition | `MADE_AVAILABLE` |
+
+These mirror `PUF_France_200_Submitted.xml`: the platform (Thomson Reuters) is the sender, the seller is the
+receiver, and `puf:ReferencedDocumentInterchangeID` carries the platform interchange ID. No `cac:Status` block.
+
+### Buyer Processing Statuses (Buyer → Seller, Invoice Response)
+
+| File | Code | Status | ResponseCode | Notes |
+|------|------|--------|--------------|-------|
+| `PUF_France_204_Acknowledged.xml` | 204 | Prise en charge | `IP` | Informational; processing started. |
+| `PUF_France_205_Approved.xml` | 205 | Approuvée | `AP` | Final approval; next step is payment. |
+| `PUF_France_206_PartiallyApproved.xml` | 206 | Approuvée partiellement | `PARTIALLY_ACCEPTED` | `MAPTTC` (approved) + `MNATTC` (not approved) amounts per VAT rate via `puf:Clarifications`; reason `QTE_ERR`. |
+| `PUF_France_Generic_UnderQuery.xml` | 207 | En litige | `UQ` | Reason `TX_TVA_ERR` + `puf:Clarifications` (DIV/DVA) + action `CNF`; detailed in §19 above. |
+| `PUF_France_208_Suspended.xml` | 208 | Suspendue | `ON_HOLD` | Reason `REF_CT_ABSENT` (missing contractual reference). |
+
+> A reason code is mandatory for **206, 207 and 208** (BR-FR-CDV-15). 207 additionally carries an
+> `OPStatusAction` block. The official AFNOR CDAR schematron confirms **207 = En litige (Litige)** and
+> **208 = Suspendue** (not the inverse some internal pages list).
+
+### Seller Statuses (Seller → Buyer, Document Status)
+
+| File | Code | Status | ResponseCode | Notes |
+|------|------|--------|--------------|-------|
+| `PUF_France_209_InformationProvided.xml` | 209 | Complétée | `INFORMATION_PROVIDED` | Fulfils a prior buyer query (e.g. after a 207 En litige). |
+| `PUF_France_220_Cancelled.xml` | 220 | Annulée | `SUPERSEDED` | Invoice annulled and superseded by a corrective invoice. |
+
+### Factoring Statuses (Document Status) — extends `PUF_France_UC10_Affacturee.xml` (225)
+
+| File | Code | Status | ResponseCode | Receiver |
+|------|------|--------|--------------|----------|
+| `PUF_France_UC10_AffactureeConfidentiel.xml` | 226 | Affacturée Confidentiel | `FACTORED_CONFIDENTIAL` | **Factor only** (not the buyer) |
+| `PUF_France_UC10_ChangementDeCompte.xml` | 227 | Changement de Compte à payer | `ACCOUNT_CHANGED` | Buyer |
+| `PUF_France_UC10_NonAffacturee.xml` | 228 | Non Affacturée | `FACTORING_CANCELLED` | Buyer |
+
+> Per XP Z12-014 (Annexe A, confidential factoring): the **226** status is shared between the seller and the
+> factor only and must **not** be transmitted to the buyer (nor the buyer's PA-R). **227** communicates the new
+> IBAN/BIC (beneficiary unchanged); **228** reverts payment to the seller's own account.
 
 ---
 


### PR DESCRIPTION
## What

Adds PUF invoice-response examples covering the remaining French CDAR statuses and documents them in the France README. Builds on top of the June merge (#19, `puf:Clarifications` + document-matching changes).

### New examples (12)
- **Platform routing** (Platform → Seller): 201 Issued, 202 Received, 203 MadeAvailable
- **Buyer processing** (Buyer → Seller): 204 Acknowledged, 205 Approved, 206 PartiallyApproved, 208 Suspended
- **Seller statuses** (Seller → Buyer): 209 InformationProvided, 220 Cancelled
- **Confidential factoring** (Document Status): 226 AffactureeConfidentiel, 227 ChangementDeCompte, 228 NonAffacturee

### Aligned with the June conventions
- **206** expresses the approved/not-approved split with `puf:Clarifications` (`MAPTTC`/`MNATTC`, gross amount in `puf:ValueAmount`), not the legacy `puf:Amounts` block.
- **207 En litige** stays covered by the canonical, already-committed `PUF_France_Generic_UnderQuery.xml` — no duplicate added. Fixed the stale `PUF_France_207_UnderQuery.xml` filename reference in README §19 (renamed to `Generic_UnderQuery.xml` in #19).
- Informational statuses (209, 220, 226-228) carry only free-text `cbc:StatusReason`; the undefined `NON` reason code is removed, since no France reason code applies outside the 206/207/208/210 matrix.

## Validation
All 37 examples pass XSD validation against `PUF-ApplicationResponse-2.3.xsd` (`validation-artefacts/validate_xsd.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)