### PR TITLE
Clarification: rename puf:ValueDateTime to puf:ValueDate; remove puf:Amounts from spec

### DIFF
--- a/examples/country-specific-examples/France/PUF_France_Generic_PaymentReceived.xml
+++ b/examples/country-specific-examples/France/PUF_France_Generic_PaymentReceived.xml
@@ -84,7 +84,7 @@
                                         -->
                                         <puf:Clarification>
                                             <puf:TypeCode>MEN</puf:TypeCode>
-                                            <puf:ValueDateTime>2026-03-01</puf:ValueDateTime>
+                                            <puf:ValueDate>2026-03-01</puf:ValueDate>
                                             <puf:ValuePercent>20</puf:ValuePercent>
                                             <puf:ValueAmount>1200.00</puf:ValueAmount>
                                             <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>

--- a/examples/country-specific-examples/France/PUF_France_UC22a_PaymentReceived_Discount.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC22a_PaymentReceived_Discount.xml
@@ -104,7 +104,7 @@
                                     <puf:Clarifications>
                                         <puf:Clarification>
                                             <puf:TypeCode>MEN</puf:TypeCode>
-                                            <puf:ValueDateTime>2026-03-18</puf:ValueDateTime>
+                                            <puf:ValueDate>2026-03-18</puf:ValueDate>
                                             <puf:ValuePercent>20</puf:ValuePercent>
                                             <puf:ValueAmount>11760.00</puf:ValueAmount>
                                             <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>

--- a/examples/country-specific-examples/France/PUF_France_UC26_PaymentReceived_Partial.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC26_PaymentReceived_Partial.xml
@@ -112,7 +112,7 @@
                                     <puf:Clarifications>
                                         <puf:Clarification>
                                             <puf:TypeCode>MEN</puf:TypeCode>
-                                            <puf:ValueDateTime>2026-06-15</puf:ValueDateTime>
+                                            <puf:ValueDate>2026-06-15</puf:ValueDate>
                                             <puf:ValuePercent>10</puf:ValuePercent>
                                             <puf:ValueAmount>20900.00</puf:ValueAmount>
                                             <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>

--- a/examples/country-specific-examples/France/PUF_France_UC34_PartialPayment.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC34_PartialPayment.xml
@@ -109,7 +109,7 @@
                                     <puf:Clarifications>
                                         <puf:Clarification>
                                             <puf:TypeCode>MEN</puf:TypeCode>
-                                            <puf:ValueDateTime>2026-02-15</puf:ValueDateTime>
+                                            <puf:ValueDate>2026-02-15</puf:ValueDate>
                                             <puf:ValuePercent>20</puf:ValuePercent>
                                             <puf:ValueAmount>600.00</puf:ValueAmount>
                                             <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>

--- a/examples/country-specific-examples/France/PUF_France_UC34_PaymentCancellation.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC34_PaymentCancellation.xml
@@ -122,7 +122,7 @@
                                     <puf:Clarifications>
                                         <puf:Clarification>
                                             <puf:TypeCode>MEN</puf:TypeCode>
-                                            <puf:ValueDateTime>2026-03-01</puf:ValueDateTime>
+                                            <puf:ValueDate>2026-03-01</puf:ValueDate>
                                             <puf:ValuePercent>20</puf:ValuePercent>
                                             <puf:ValueAmount>-1200.00</puf:ValueAmount>
                                             <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>

--- a/examples/country-specific-examples/France/PUF_France_UC41_Barter_Encaissee.xml
+++ b/examples/country-specific-examples/France/PUF_France_UC41_Barter_Encaissee.xml
@@ -131,14 +131,14 @@
                                     <puf:Clarifications>
                                         <puf:Clarification>
                                             <puf:TypeCode>MEN</puf:TypeCode>
-                                            <puf:ValueDateTime>2026-02-28</puf:ValueDateTime>
+                                            <puf:ValueDate>2026-02-28</puf:ValueDate>
                                             <puf:ValuePercent>20</puf:ValuePercent>
                                             <puf:ValueAmount>12000.00</puf:ValueAmount>
                                             <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>
                                         </puf:Clarification>
                                         <puf:Clarification>
                                             <puf:TypeCode>MEN</puf:TypeCode>
-                                            <puf:ValueDateTime>2026-02-28</puf:ValueDateTime>
+                                            <puf:ValueDate>2026-02-28</puf:ValueDate>
                                             <puf:ValuePercent>0</puf:ValuePercent>
                                             <puf:ValueAmount>-10000.00</puf:ValueAmount>
                                             <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>

--- a/examples/country-specific-examples/France/README.md
+++ b/examples/country-specific-examples/France/README.md
@@ -305,7 +305,7 @@ Reference: `FR-UC34-INV-2026-001` (same invoice as UC34_PartialPayment)
 Demonstrates a correction Encaissée using a NEGATIVE MEN to cancel a previously-declared payment receipt:
 - MEN = **-1,200.00 EUR TTC @ 20%** — reversal of a full payment previously declared in error
 - `puf:ValueAmount` = -1,200.00 EUR (gross / TTC), `puf:ValueAmountCurrency` = EUR
-- `puf:ValueDateTime` = date the bank reversal was confirmed (2026-03-01)
+- `puf:ValueDate` = date the bank reversal was confirmed (2026-03-01)
 
 > The response code remains `PAYMENT_RECEIVED`. Only the `puf:ValueAmount`
 > becomes negative to signal the reversal. Net effect: the prior positive declaration is cancelled.
@@ -460,7 +460,7 @@ Always wrap `puf:DocumentMatchingID` inside `puf:ResponseExtension`:
 
 A `puf:StatusExtension` with a `MEN` clarification is **mandatory** for Encaissée, broken down by
 VAT rate. (The `MEN` amount is carried in `puf:ValueAmount`/`puf:ValueAmountCurrency`, the VAT rate
-in `puf:ValuePercent`. The legacy `puf:Amounts` structure is superseded by `puf:Clarifications`.)
+in `puf:ValuePercent`.)
 
 ```xml
 <cac:Status>

--- a/index.html
+++ b/index.html
@@ -1800,7 +1800,7 @@ The attached document embedded as binary object (Base64).</p></td>
 <p>Below tables shows the definition of elements added to the extension <code>puf:PageroExtension/puf:StatusExtension</code>.</p>
 </div>
 <div class="paragraph">
-<p>Status-level information is carried in <code>puf:Clarifications</code> (see below). The older <code>puf:Amounts</code> structure is <strong>legacy</strong> — it is retained for backwards compatibility but is <strong>superseded by <code>puf:Clarifications</code></strong>; new producers should use <code>puf:Clarifications</code>, expressing a monetary amount with <code>puf:TypeCode</code> + <code>puf:ValueAmount</code>/<code>puf:ValueAmountCurrency</code> (+ <code>puf:ValuePercent</code> for the VAT rate).</p>
+<p>Status-level information is carried in <code>puf:Clarifications</code> (see below). Express a monetary amount with <code>puf:TypeCode</code> + <code>puf:ValueAmount</code>/<code>puf:ValueAmountCurrency</code> (+ <code>puf:ValuePercent</code> for the VAT rate).</p>
 </div>
 <table class="tableblock frame-all grid-all stretch status-extension-table">
 <caption class="title">Table 9. Elements added in puf:StatusExtension relating to clarifications.</caption>
@@ -1861,9 +1861,9 @@ Value of the field expressed as text. Use the value element matching the value&#
 Value of the field expressed as a code.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Clarifications/puf:Clarification/puf:ValueDateTime</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Date/time value</strong><br>
-Value of the field expressed as a date/time.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Clarifications/puf:Clarification/puf:ValueDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Date value</strong><br>
+Value of the field expressed as a date.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Clarifications/puf:Clarification/puf:ValueNumeric</code></p></td>
@@ -1895,47 +1895,6 @@ Value of the field expressed as a measure, and its unit-of-measure code.</p></td
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch status-extension-table">
-<caption class="title">Table 10. Elements added in puf:StatusExtension relating to amounts (<strong>legacy</strong> — superseded by puf:Clarifications).</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Amounts/puf:Amount/puf:AmountType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Amount type</strong> (<strong>legacy</strong>)<br>
-The type of amount that is being specified.<br>
-AmountType code currently depend on country guidelines. See section <a href="#_country_specifics">Country specifics</a> for more details on how it&#8217;s handled in each country.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Amounts/puf:Amount/cbc:TaxExclusiveAmount</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Net amount</strong> (<strong>legacy</strong>)<br>
-The net amount (excl. taxes) for the specified amount type.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Amounts/puf:Amount/cbc:TaxInclusiveAmount</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total amount</strong> (<strong>legacy</strong>)<br>
-The total amount (incl. taxes) for the specified amount type.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Amounts/puf:Amount/cac:ClassifiedTaxCategory/cbc:Percent</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax rate</strong> (<strong>legacy</strong>)<br>
-The tax rate applicable for the specified amount type.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Amounts/puf:Amount/puf:Date</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Date</strong> (<strong>legacy</strong>)<br>
-A date associated with the amount entry (e.g. payment collection date).</p></td>
-</tr>
-</tbody>
-</table>
 <div class="paragraph">
 <p>See example below as well as the URI to be used for this extension.</p>
 </div>
@@ -1964,7 +1923,7 @@ A date associated with the amount entry (e.g. payment collection date).</p></td>
                                             <span class="tag">&lt;puf:ValueAmount&gt;</span>120.00<span class="tag">&lt;/puf:ValueAmount&gt;</span>
                                             <span class="tag">&lt;puf:ValueAmountCurrency&gt;</span>EUR<span class="tag">&lt;/puf:ValueAmountCurrency&gt;</span>
                                             <span class="tag">&lt;puf:ValuePercent&gt;</span>20<span class="tag">&lt;/puf:ValuePercent&gt;</span>
-                                            <span class="tag">&lt;puf:ValueDateTime&gt;</span>2026-01-15<span class="tag">&lt;/puf:ValueDateTime&gt;</span>
+                                            <span class="tag">&lt;puf:ValueDate&gt;</span>2026-01-15<span class="tag">&lt;/puf:ValueDate&gt;</span>
                                         <span class="tag">&lt;/puf:Clarification&gt;</span>
                                         <span class="tag">&lt;puf:Clarification&gt;</span>
                                             <span class="tag">&lt;puf:TypeCode&gt;</span>MEN<span class="tag">&lt;/puf:TypeCode&gt;</span>
@@ -2019,10 +1978,10 @@ A date associated with the amount entry (e.g. payment collection date).</p></td>
 <div class="sect4">
 <h5 id="_amount_type"><a class="anchor" href="#_amount_type"></a><a class="link" href="#_amount_type">Amount Type</a></h5>
 <div class="paragraph">
-<p>The clarification type code (<code>puf:Clarification/puf:TypeCode</code>; legacy: <code>puf:AmountType</code>) is used to indicate what the specified amounts mean. In France, the following list is applicable:</p>
+<p>The clarification type code (<code>puf:Clarification/puf:TypeCode</code>) is used to indicate what the specified amounts mean. In France, the following list is applicable:</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 11. puf:TypeCode (amount type) values applicable in France</caption>
+<caption class="title">Table 10. puf:TypeCode (amount type) values applicable in France</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2181,7 +2140,7 @@ Each <code>puf:Clarification</code> carries a single <code>puf:ValueAmount</code
 <p>In France, the reason codes are unique and defined in the table below. The table also indicates for which response codes (<code>cbc:ResponseCode</code>) each reason code is applicable.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 12. French reason codes and applicability per response code</caption>
+<caption class="title">Table 11. French reason codes and applicability per response code</caption>
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 21.4285%;">
@@ -2518,7 +2477,7 @@ These reason codes, their labels and their applicability per status are defined 
 <div class="sect2">
 <h3 id="_code_lists_for_coded_elements"><a class="anchor" href="#_code_lists_for_coded_elements"></a><a class="link" href="#_code_lists_for_coded_elements">6.1. Code lists for coded elements</a></h3>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 13. Table of the code lists used</caption>
+<caption class="title">Table 12. Table of the code lists used</caption>
 <colgroup>
 <col>
 <col>

--- a/specification/country-specifics/france.adoc
+++ b/specification/country-specifics/france.adoc
@@ -7,7 +7,7 @@ In France it is a requirement to report received payments for certain transactio
 
 ===== Amount Type
 
-The clarification type code (``puf:Clarification/puf:TypeCode``; legacy: ``puf:AmountType``) is used to indicate what the specified amounts mean. In France, the following list is applicable:
+The clarification type code (``puf:Clarification/puf:TypeCode``) is used to indicate what the specified amounts mean. In France, the following list is applicable:
 
 .puf:TypeCode (amount type) values applicable in France
 |===

--- a/specification/extensions/ubl-root-application-response/status-extension.adoc
+++ b/specification/extensions/ubl-root-application-response/status-extension.adoc
@@ -2,7 +2,7 @@
 
 Below tables shows the definition of elements added to the extension `puf:PageroExtension/puf:StatusExtension`.
 
-Status-level information is carried in `puf:Clarifications` (see below). The older `puf:Amounts` structure is *legacy* — it is retained for backwards compatibility but is **superseded by `puf:Clarifications`**; new producers should use `puf:Clarifications`, expressing a monetary amount with `puf:TypeCode` + `puf:ValueAmount`/`puf:ValueAmountCurrency` (+ `puf:ValuePercent` for the VAT rate).
+Status-level information is carried in `puf:Clarifications` (see below). Express a monetary amount with `puf:TypeCode` + `puf:ValueAmount`/`puf:ValueAmountCurrency` (+ `puf:ValuePercent` for the VAT rate).
 
 .Elements added in puf:StatusExtension relating to clarifications.
 [.status-extension-table]
@@ -46,9 +46,9 @@ Value of the field expressed as text. Use the value element matching the value's
 |**Coded value** +
 Value of the field expressed as a code.
 
-|`puf:Clarifications/puf:Clarification/puf:ValueDateTime`
-|**Date/time value** +
-Value of the field expressed as a date/time.
+|`puf:Clarifications/puf:Clarification/puf:ValueDate`
+|**Date value** +
+Value of the field expressed as a date.
 
 |`puf:Clarifications/puf:Clarification/puf:ValueNumeric`
 |**Numeric value** +
@@ -72,34 +72,6 @@ Value of the field expressed as a quantity, and its unit-of-measure code.
 puf:Clarifications/puf:Clarification/puf:ValueMeasureUnit`
 |**Measure value / unit** +
 Value of the field expressed as a measure, and its unit-of-measure code.
-|===
-
-.Elements added in puf:StatusExtension relating to amounts (*legacy* — superseded by puf:Clarifications).
-[.status-extension-table]
-[%stretch,cols="1,1"]
-|===
-|Element |Description
-
-|`puf:Amounts/puf:Amount/puf:AmountType`
-|**Amount type** (*legacy*) +
-The type of amount that is being specified. +
-AmountType code currently depend on country guidelines. See section <<_country_specifics>> for more details on how it's handled in each country.
-
-|`puf:Amounts/puf:Amount/cbc:TaxExclusiveAmount`
-|**Net amount** (*legacy*) +
-The net amount (excl. taxes) for the specified amount type.
-
-|`puf:Amounts/puf:Amount/cbc:TaxInclusiveAmount`
-|**Total amount** (*legacy*) +
-The total amount (incl. taxes) for the specified amount type.
-
-|`puf:Amounts/puf:Amount/cac:ClassifiedTaxCategory/cbc:Percent`
-|**Tax rate** (*legacy*) +
-The tax rate applicable for the specified amount type.
-
-|`puf:Amounts/puf:Amount/puf:Date`
-|**Date** (*legacy*) +
-A date associated with the amount entry (e.g. payment collection date).
 |===
 
 See example below as well as the URI to be used for this extension.
@@ -128,7 +100,7 @@ _puf:StatusExtension with sample values. The example scenario illustrated below 
                                             <puf:ValueAmount>120.00</puf:ValueAmount>
                                             <puf:ValueAmountCurrency>EUR</puf:ValueAmountCurrency>
                                             <puf:ValuePercent>20</puf:ValuePercent>
-                                            <puf:ValueDateTime>2026-01-15</puf:ValueDateTime>
+                                            <puf:ValueDate>2026-01-15</puf:ValueDate>
                                         </puf:Clarification>
                                         <puf:Clarification>
                                             <puf:TypeCode>MEN</puf:TypeCode>

--- a/xml-schemas/extensions/PUF-ExtensionComponent.xsd
+++ b/xml-schemas/extensions/PUF-ExtensionComponent.xsd
@@ -220,8 +220,8 @@
             <xsd:element name="ValueCode" type="PUFCodeType" minOccurs="0" maxOccurs="1">
                 <xsd:annotation><xsd:documentation>Value of the field expressed as a code.</xsd:documentation></xsd:annotation>
             </xsd:element>
-            <xsd:element name="ValueDateTime" type="PUFDateType" minOccurs="0" maxOccurs="1">
-                <xsd:annotation><xsd:documentation>Value of the field expressed as a date/time.</xsd:documentation></xsd:annotation>
+            <xsd:element name="ValueDate" type="PUFDateType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation><xsd:documentation>Value of the field expressed as a date.</xsd:documentation></xsd:annotation>
             </xsd:element>
             <xsd:element name="ValueNumeric" type="PUFTextType" minOccurs="0" maxOccurs="1">
                 <xsd:annotation><xsd:documentation>Value of the field expressed as a number.</xsd:documentation></xsd:annotation>


### PR DESCRIPTION
## What
- Rename clarification date element `puf:ValueDateTime` -> `puf:ValueDate` (schema, 6 France examples, spec).
- Remove `puf:Amounts` from the **specification** so `puf:Clarifications` is the only documented path.

## Why
- The clarification date value is date-only (aligns with the internal `valueDate` model and the date-only CDAR `ValueDateTime` per AFNOR XP Z12-012).
- `puf:Amounts` is legacy; the spec should be unequivocal that `puf:Clarifications` is the way forward.

## Scope / retained
- `puf:Amounts` is **kept in the schema** (`PUF-ExtensionComponent.xsd`) and **still handled in the transformations** for customers already using it — only the spec stops documenting it.

## Changes
- `PUF-ExtensionComponent.xsd`: `ValueDateTime` -> `ValueDate` (type `PUFDateType` unchanged).
- `status-extension.adoc`: rename + removed the legacy Amounts table and intro mention.
- `france.adoc`: dropped the `legacy: puf:AmountType` aside.
- 6 France example XMLs + examples `README.md`: rename; removed Amounts note.
- `index.html` regenerated.

## Validation
- All examples validate against the PUF ApplicationResponse XSD (37/37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
